### PR TITLE
Fixed windows path bug

### DIFF
--- a/coffeescript/templatetags/coffeescript.py
+++ b/coffeescript/templatetags/coffeescript.py
@@ -94,4 +94,4 @@ def coffeescript(path):
                 if filename.startswith(base_filename) and filename != compiled_filename:
                     os.remove(os.path.join(output_directory, filename))
 
-    return output_path[len(STATIC_ROOT):].lstrip("/")
+    return output_path[len(STATIC_ROOT):].replace(os.sep, '/').lstrip("/")


### PR DESCRIPTION
In windows output_path looks like "\COFFEESCRIPT_CACHE.....", so you need to transform backslashes to slashes.
