### PR TITLE
shlex.split enforce unc paths under windows

### DIFF
--- a/coffeescript/settings.py
+++ b/coffeescript/settings.py
@@ -1,6 +1,8 @@
 from django.conf import settings
+import os
 
 
+POSIX_COMPATIBLE = True if os.name == 'posix' else False
 COFFEESCRIPT_EXECUTABLE = getattr(settings, "COFFEESCRIPT_EXECUTABLE", "coffee")
 COFFEESCRIPT_USE_CACHE = getattr(settings, "COFFEESCRIPT_USE_CACHE", True)
 COFFEESCRIPT_CACHE_TIMEOUT = getattr(settings, "COFFEESCRIPT_CACHE_TIMEOUT", 60 * 60 * 24 * 30) # 30 days

--- a/coffeescript/templatetags/coffeescript.py
+++ b/coffeescript/templatetags/coffeescript.py
@@ -1,6 +1,6 @@
 from ..cache import get_cache_key, get_hexdigest, get_hashed_mtime
 from ..settings import COFFEESCRIPT_EXECUTABLE, COFFEESCRIPT_USE_CACHE,\
-    COFFEESCRIPT_CACHE_TIMEOUT, COFFEESCRIPT_OUTPUT_DIR
+    COFFEESCRIPT_CACHE_TIMEOUT, COFFEESCRIPT_OUTPUT_DIR, POSIX_COMPATIBLE
 from django.conf import settings
 from django.core.cache import cache
 from django.template.base import Library, Node
@@ -20,7 +20,7 @@ class InlineCoffeescriptNode(Node):
         self.nodelist = nodelist
 
     def compile(self, source):
-        args = shlex.split("%s -c -s -p" % COFFEESCRIPT_EXECUTABLE)
+        args = shlex.split("%s -c -s -p" % COFFEESCRIPT_EXECUTABLE, posix=POSIX_COMPATIBLE)
 
         p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         out, errors = p.communicate(source.encode("utf-8"))
@@ -80,7 +80,7 @@ def coffeescript(path):
         source = source_file.read()
         source_file.close()
 
-        args = shlex.split("%s -c -s -p" % COFFEESCRIPT_EXECUTABLE)
+        args = shlex.split("%s -c -s -p" % COFFEESCRIPT_EXECUTABLE, posix=POSIX_COMPATIBLE)
         p = subprocess.Popen(args, stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, errors = p.communicate(source)


### PR DESCRIPTION
Under windows, backslashes in COFFEESCRIPT_EXECUTABLE path were being stripped by the shlex.split function..   apparently setting posix=False preserves the UNC style path..

Thanks for a great app, really awesome!
